### PR TITLE
Add support for voryx/thruway 0.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require": {
-        "voryx/thruway": "^0.5.0|^0.6.0",
+        "voryx/thruway": "^0.5.0 || ^0.6.0",
         "react/http": "^0.8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require": {
-        "voryx/thruway": "^0.5.0",
+        "voryx/thruway": "^0.5.0|^0.6.0",
         "react/http": "^0.8.0"
     },
     "require-dev": {


### PR DESCRIPTION
I need this to remove symfony deprecation messages from logs